### PR TITLE
fix(elfinder): prevent path traversal in decode() method

### DIFF
--- a/src/server/elfinderConnector.ts
+++ b/src/server/elfinderConnector.ts
@@ -24,13 +24,23 @@ export class ElFinderConnector {
     // 解码hash为路径
     private decode(hash: string): string {
         if (hash.startsWith('TMP_')) {
-            return Buffer.from(hash.substring(4), 'base64').toString('utf-8')
+            const tmpPath = Buffer.from(hash.substring(4), 'base64').toString('utf-8')
+            const resolved = path.resolve(tmpPath)
+            const tmpDir = require('os').tmpdir()
+            if (!resolved.startsWith(tmpDir + path.sep) && resolved !== tmpDir) {
+                throw new Error('Invalid temporary path')
+            }
+            return resolved
         }
         try {
             const rawHash = hash.startsWith('l1_') ? hash.substring(3) : hash
             const base64 = rawHash.replace(/-/g, '+').replace(/_/g, '/')
             const relative = Buffer.from(base64, 'base64').toString('utf-8')
-            return path.join(this.root, relative)
+            const resolved = path.resolve(this.root, relative)
+            if (!resolved.startsWith(this.root + path.sep) && resolved !== this.root) {
+                throw new Error('Path traversal detected')
+            }
+            return resolved
         } catch {
             return this.root
         }


### PR DESCRIPTION
## 📝 修改描述 (Description)

Fix a path traversal vulnerability (CWE-22) in `ElFinderConnector.decode()` (`src/server/elfinderConnector.ts`). The `decode()` method converts client-supplied base64-encoded hashes back into filesystem paths, but does not validate that the resulting path stays within the intended root directory. An authenticated user can craft a hash containing `../../` sequences to read, write, or delete files anywhere on the server's filesystem.

### Vulnerability details

The `decode()` method has two code paths, both vulnerable:

1. **`l1_` prefix path** (line 31): The base64-decoded string is joined with `this.root` via `path.join()`, but `path.join()` does not prevent traversal — `path.join('/app', '../../etc/passwd')` resolves to `/etc/passwd`. Since `decode()` is called by every elFinder command (`open`, `file`, `get`, `put`, `rm`, `mkdir`, etc.), an attacker can perform arbitrary file operations outside the intended root.

2. **`TMP_` prefix path** (line 27): The base64-decoded string is used directly as an absolute path with no validation, allowing access to any file on the filesystem.

### Proof of Concept

An authenticated attacker (knowing the `frontend.password`) can exploit this via the `/api/elfinder/connector` endpoint:

```bash
# Encode a traversal payload: "../../etc/passwd"
PAYLOAD=$(echo -n "../../etc/passwd" | base64)
# Result: Li4vLi4vZXRjL3Bhc3N3ZA==

# URL-safe base64 (replace + with -, / with _)
SAFE_PAYLOAD=$(echo "$PAYLOAD" | tr '+/' '-_')

# Read /etc/passwd via the file manager
curl -s "http://localhost:9527/api/elfinder/connector?cmd=get&target=l1_${SAFE_PAYLOAD}" \
  -H "x-frontend-auth: YOUR_FRONTEND_PASSWORD"
```

For the `TMP_` path, an attacker can similarly encode any absolute path:

```bash
TMP_PAYLOAD=$(echo -n "/etc/shadow" | base64)
curl -s "http://localhost:9527/api/elfinder/connector?cmd=get&target=TMP_${TMP_PAYLOAD}" \
  -H "x-frontend-auth: YOUR_FRONTEND_PASSWORD"
```

### Preconditions

- The attacker must know the `frontend.password` (checked at `server.ts:4309`). However, this password grants access to the file manager scoped to the configured root — it does not grant arbitrary filesystem access. The traversal breaks that intended scope boundary.

### Fix description

The fix adds `path.resolve()` + `startsWith()` containment checks to both code paths in `decode()`:

- For `l1_` hashes: the resolved path must start with `this.root` (the configured system root).
- For `TMP_` hashes: the resolved path must start with the OS temp directory (`os.tmpdir()`).

If the resolved path escapes the allowed directory, an error is thrown, which the existing `catch` block in the `l1_` path handles gracefully by returning `this.root`. The `TMP_` path throws explicitly.

This is the standard mitigation for CWE-22 in Node.js — `path.resolve()` canonicalizes the path (collapsing `..`), and `startsWith(root + path.sep)` ensures the result is a child of the allowed directory.

## 🆎 修改类型 (Type of Change)

- [x] 🐛 Bug 修复 (Fix)
- [ ] ✨ 新功能 (Feature)
- [ ] 📚 文档修改 (Docs)
- [ ] 🔧 代码重构或优化 (Refactor/Style)

## ✅ 提交前检查清单 (Checklist)

- [x] 我已将代码合并到了 **`dev`** 分支，而不是 `main`。
- [x] 我已在本地解决了与 `dev` 分支的所有 **合并冲突 (Merge Conflicts)**。
- [x] 我的代码在本地测试通过，没有报错。
- [ ] 我更新了对应的文档（如果适用）。

## Testing

- Verified that `path.resolve('/app/data', '../../etc/passwd')` produces `/etc/passwd`, which does **not** start with `/app/data/` — confirming the traversal is blocked by the fix.
- Verified that legitimate paths like `path.resolve('/app/data', 'music/file.mp3')` produce `/app/data/music/file.mp3`, which passes the check — no regression for normal usage.
- Verified the `TMP_` path similarly blocks traversal outside `os.tmpdir()`.

## Adversarial review

Before submitting, we attempted to disprove this finding: we checked whether the `frontend.password` authentication gate at `server.ts:4309` would make this unexploitable. It doesn't — the password is a shared secret that grants access to the scoped file manager, not to the entire filesystem. The traversal allows an authenticated user to exceed their intended access scope. We also verified the route and `decode()` method exist in the current codebase and that no other sanitization is applied between user input and the filesystem operations.

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file path validation to prevent unauthorized access and path traversal vulnerabilities.
  * Improved temporary file path handling to ensure files remain within secure system directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->