### PR TITLE
fix: enable lm-quick-search and sync quick search filter state

### DIFF
--- a/public/music/js/local_music.js
+++ b/public/music/js/local_music.js
@@ -378,6 +378,8 @@ window.LocalMusicManager = {
             };
 
             if (!matchKeywords(k)) return false;
+            if (qk && !matchKeywords(qk)) return false;
+
             // SubPath check
             if (this.selectedSubPath !== '') {
                 const target = this.selectedSubPath === '__ROOT__' ? '' : this.selectedSubPath;
@@ -443,7 +445,7 @@ window.LocalMusicManager = {
 
         // 4. Update UI Indicator
         const dot = document.getElementById('lm-filter-active-dot');
-        const hasActiveFilters = this.searchKeyword || this.filterQuality.size > 0 || this.filterFolder !== 'all' || this.filterStatus.size > 0 || this.filterSource.size > 0;
+        const hasActiveFilters = this.searchKeyword || this.quickSearchKeyword || this.filterQuality.size > 0 || this.filterFolder !== 'all' || this.filterStatus.size > 0 || this.filterSource.size > 0;
         if (dot) {
             if (hasActiveFilters) dot.classList.remove('hidden');
             else dot.classList.add('hidden');


### PR DESCRIPTION
## 📝 修改描述 (Description)

<!-- 请简要描述你修复的 Bug 或添加的功能 -->
fix issue #231 

## 🆎 修改类型 (Type of Change)

- [ ] 🐛 Bug 修复 (Fix)
搜索框无效

## ✅ 提交前检查清单 (Checklist)

**在提交之前，请确保你完成了以下步骤：**

- [ ] 我已将代码合并到了 **`dev`** 分支，而不是 `main`。


## 📸 截图 (Screenshots - 可选)
<img width="1990" height="685" alt="5c33729c-aaac-4961-ae60-05f7f9936099" src="https://github.com/user-attachments/assets/d7d07231-4fe6-4dd7-93b6-a47485b966f3" />
<img width="1990" height="685" alt="5c33729c-aaac-4961-ae60-05f7f9936099" src="https://github.com/user-attachments/assets/d7d07231-4fe6-4dd7-93b6-a47485b966f3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quick search now properly applies as an additional filter alongside main search input
  * Filter indicator now accurately reflects quick search filter status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->