### PR TITLE
fix: reuse auto source switching for downloads

### DIFF
--- a/public/music/app.js
+++ b/public/music/app.js
@@ -2726,12 +2726,20 @@ async function resolveSongUrl(song, quality, isSilent = false, isRetry = false, 
             } else if (step === 'switch_platform') {
                 if (!isSilent) {
                     console.log(`[AutoSource] 原始源解析失败，准备尝试全网匹配: ${song.name}`);
-                    const matchedSong = await findOtherSourceMatch(song);
-                    if (matchedSong) {
+                }
+                const matchedSong = await findOtherSourceMatch(song, isSilent);
+                if (matchedSong) {
+                    if (!isSilent) {
                         showInfo(`找到备选源，尝试从 ${getSourceName(matchedSong.source)} 播放...`);
-                        const bestNextQuality = window.QualityManager.getBestQuality(matchedSong, settings.preferredQuality || '320k');
-                        return await fetchSongUrl(matchedSong, bestNextQuality, true, isSilent);
                     }
+                    const bestNextQuality = window.QualityManager.getBestQuality(matchedSong, settings.preferredQuality || '320k');
+                    const matchedResult = await fetchSongUrl(matchedSong, bestNextQuality, true, isSilent);
+                    return {
+                        ...matchedResult,
+                        songInfo: matchedSong,
+                        switchedSource: true,
+                        originalSource: song.source
+                    };
                 }
             }
         }
@@ -2744,7 +2752,7 @@ async function resolveSongUrl(song, quality, isSilent = false, isRetry = false, 
  * 跨平台寻找相同歌曲的匹配逻辑
  * 基本规则：歌名+歌手+时长匹配
  */
-async function findOtherSourceMatch(song) {
+async function findOtherSourceMatch(song, isSilent = false) {
     if (!song.name || !song.singer) return null;
 
     try {
@@ -2775,7 +2783,7 @@ async function findOtherSourceMatch(song) {
         // 4. 如果发现没有其他支持的平台可供切换
         if (searchSources.length === 0) {
             console.log(`[AutoSource] 换源跳过：没有其他自定义源支持的平台。当前源: ${song.source}`);
-            showError('未找到自定义源下支持的平台下的对应歌曲');
+            if (!isSilent) showError('未找到自定义源下支持的平台下的对应歌曲');
             return null;
         }
 
@@ -2783,7 +2791,7 @@ async function findOtherSourceMatch(song) {
         const headers = { 'Content-Type': 'application/json' };
         Object.assign(headers, getUserAuthHeaders());
 
-        showInfo('正在自动尝试换源匹配...');
+        if (!isSilent) showInfo('正在自动尝试换源匹配...');
 
         const searchPromises = searchSources.map(s =>
             fetch(`${API_BASE}/search?name=${encodeURIComponent(query)}&source=${s}&page=1`, { headers })
@@ -3017,6 +3025,7 @@ async function fetchSongUrl(song, quality, isRetry = false, isSilent = false) {
                 sourceType: 'normal',
                 quality: result.type || quality,
                 sourceName: result.sourceName,
+                songInfo: song,
                 errorMsg: result.errorMsg
             };
         }
@@ -12308,5 +12317,3 @@ document.addEventListener('click', (e) => {
 document.addEventListener('DOMContentLoaded', () => {
     window.CustomSelectManager.initAll();
 });
-
-

--- a/public/music/js/download_manager.js
+++ b/public/music/js/download_manager.js
@@ -27,6 +27,17 @@ class DownloadManager {
         this.restoreTasks();
     }
 
+    extractRawDownloadUrl(url) {
+        if (!url || !url.startsWith('/api/music/download')) return url;
+        try {
+            const proxyParams = new URLSearchParams(url.includes('?') ? url.split('?')[1] : '');
+            const extracted = proxyParams.get('url');
+            return extracted ? decodeURIComponent(extracted) : url;
+        } catch (e) {
+            return url;
+        }
+    }
+
     // Update max concurrency limit dynamically
     updateMaxConcurrent(value) {
         console.log('[DownloadManager] Concurrency limit updated to:', value);
@@ -391,13 +402,13 @@ class DownloadManager {
             const result = await resolveSongUrl(task.song, quality, true, true);
             if (!result || !result.url) throw new Error('解析失败');
 
-
-            let rawUrl = result.url;
-            if (rawUrl.startsWith('/api/music/download')) {
-                const proxyParams = new URLSearchParams(rawUrl.includes('?') ? rawUrl.split('?')[1] : '');
-                const extracted = proxyParams.get('url');
-                if (extracted) rawUrl = decodeURIComponent(extracted);
+            const resolvedSong = result.songInfo || task.song;
+            if (resolvedSong !== task.song) {
+                task.song = resolvedSong;
+                this.renderTask(task);
             }
+
+            let rawUrl = this.extractRawDownloadUrl(result.url);
             if (!rawUrl.startsWith('http')) throw new Error('无法获取有效的外部下载地址');
 
             // 2. Post to backend
@@ -407,7 +418,7 @@ class DownloadManager {
                 method: 'POST',
                 headers,
                 body: JSON.stringify({ 
-                    songInfo: task.song, 
+                    songInfo: resolvedSong,
                     url: rawUrl, 
                     quality, 
                     enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false,
@@ -464,23 +475,18 @@ class DownloadManager {
                     if (path.includes('.')) ext = path.split('.').pop();
                 } catch (e) { }
             } else {
-                // 2. 无缓存，向原站解析 URL
-                const headers = { 'Content-Type': 'application/json', ...(window.getUserAuthHeaders ? window.getUserAuthHeaders() : {}) };
+                if (typeof resolveSongUrl !== 'function') throw new Error('resolveSongUrl missing');
+                const resolveData = await resolveSongUrl(task.song, quality, true, true);
+                if (!resolveData || !resolveData.url) throw new Error('No download URL found');
 
-                const resolveRes = await fetch('/api/music/url', {
-                    method: 'POST',
-                    headers,
-                    body: JSON.stringify({ songInfo: task.song, quality }),
-                    signal: task.controller.signal
-                });
-
-                if (!resolveRes.ok) throw new Error('Failed to resolve URL');
-                const resolveData = await resolveRes.json();
-
-                if (!resolveData.url) throw new Error('No download URL found');
+                const resolvedSong = resolveData.songInfo || task.song;
+                if (resolvedSong !== task.song) {
+                    task.song = resolvedSong;
+                    this.renderTask(task);
+                }
 
                 finalUrl = resolveData.url;
-                ext = resolveData.type || 'mp3';
+                ext = resolveData.quality || resolveData.type || 'mp3';
                 if (ext.startsWith('flac')) ext = 'flac'; // Handle flac24bit -> flac
                 if (ext === '128k' || ext === '320k') ext = 'mp3';
             }
@@ -508,6 +514,7 @@ class DownloadManager {
 
             // [优化] 如果是本地缓存文件，不需要经过下载代理（已经有标签了）
             const isLocalCache = finalUrl.startsWith('/api/music/cache/file');
+            finalUrl = this.extractRawDownloadUrl(finalUrl);
 
             if (shouldProxyDownload && !finalUrl.startsWith('/api/music/download') && !isLocalCache) {
                 // Add metadata for tagging — 用 albumName 优先（playlist 字段），album 为兼容备选
@@ -711,13 +718,14 @@ class DownloadManager {
                     const result = await resolveSongUrl(task.song, quality, true, true);
                     if (!result || !result.url) throw new Error('获取播放地址失败');
 
-                    // [Fix] 还原代理 URL 为原始外部 URL
-                    let rawUrl = result.url;
-                    if (rawUrl.startsWith('/api/music/download')) {
-                        const proxyParams = new URLSearchParams(rawUrl.includes('?') ? rawUrl.split('?')[1] : '');
-                        const extracted = proxyParams.get('url');
-                        if (extracted) rawUrl = decodeURIComponent(extracted);
+                    const resolvedSong = result.songInfo || task.song;
+                    if (resolvedSong !== task.song) {
+                        task.song = resolvedSong;
+                        this.renderTask(task);
                     }
+
+                    // [Fix] 还原代理 URL 为原始外部 URL
+                    let rawUrl = this.extractRawDownloadUrl(result.url);
                     if (!rawUrl.startsWith('http')) throw new Error('无法获取有效的外部下载地址');
 
                     const headers = { 'Content-Type': 'application/json', ...(window.getUserAuthHeaders ? window.getUserAuthHeaders() : {}) };
@@ -725,7 +733,7 @@ class DownloadManager {
                     const res = await fetch('/api/music/cache/download', {
                         method: 'POST',
                         headers,
-                        body: JSON.stringify({ songInfo: task.song, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false })
+                        body: JSON.stringify({ songInfo: resolvedSong, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false })
                     });
                     if (!res.ok) throw new Error('服务器拒绝请求');
 
@@ -815,13 +823,14 @@ class DownloadManager {
                         const result = await resolveSongUrl(t.song, quality, true, true);
                         if (!result || !result.url) throw new Error('获取地址失败');
 
-                        // [Fix] 还原代理 URL 为原始外部 URL
-                        let rawUrl = result.url;
-                        if (rawUrl.startsWith('/api/music/download')) {
-                            const proxyParams = new URLSearchParams(rawUrl.includes('?') ? rawUrl.split('?')[1] : '');
-                            const extracted = proxyParams.get('url');
-                            if (extracted) rawUrl = decodeURIComponent(extracted);
+                        const resolvedSong = result.songInfo || t.song;
+                        if (resolvedSong !== t.song) {
+                            t.song = resolvedSong;
+                            this.renderTask(t);
                         }
+
+                        // [Fix] 还原代理 URL 为原始外部 URL
+                        let rawUrl = this.extractRawDownloadUrl(result.url);
                         if (!rawUrl.startsWith('http')) throw new Error('无法获取有效的外部下载地址');
 
                         const headers = { 'Content-Type': 'application/json', ...(window.getUserAuthHeaders ? window.getUserAuthHeaders() : {}) };
@@ -829,7 +838,7 @@ class DownloadManager {
                         const res = await fetch('/api/music/cache/download', {
                             method: 'POST',
                             headers,
-                            body: JSON.stringify({ songInfo: t.song, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false })
+                            body: JSON.stringify({ songInfo: resolvedSong, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false })
                         });
                         if (!res.ok) throw new Error('服务器拒绝缓存');
 


### PR DESCRIPTION
## 📝 修改描述 (Description)

<!-- 请简要描述你修复的 Bug 或添加的功能 -->
修复直接下载歌单里面的歌曲，不会自动切换平台的问题。

## 🆎 修改类型 (Type of Change)

- [ ] 🐛 Bug 修复 (Fix)


## ✅ 提交前检查清单 (Checklist)

**在提交之前，请确保你完成了以下步骤：**

- [ ] 我已将代码合并到了 **`dev`** 分支，而不是 `main`。


## 📸 截图 (Screenshots - 可选)
<img width="2343" height="730" alt="945bc25f-0b59-4f20-bd07-51894a2ccf1b" src="https://github.com/user-attachments/assets/8b09f52e-5ddb-4ff6-82e6-0dd721c53c5a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic music source switching now operates silently when needed, eliminating unnecessary interruptions during playback
  * Enhanced metadata and source tracking information provided during music source transitions for better transparency
  * Improved download URL handling with better cross-source compatibility for more reliable downloads
  * Real-time server-side download progress tracking with periodic monitoring updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->