### PR TITLE
fix: cache lyrics for playlist server downloads

### DIFF
--- a/public/music/js/download_manager.js
+++ b/public/music/js/download_manager.js
@@ -161,15 +161,18 @@ class DownloadManager {
         if (!task || !task.isServer || task.status !== 'finished') return;
 
         // [优化] 如果已经有结果，或者重试超过 3 次，则不再请求
-        if (task.hasLyric !== undefined || (task.lyricRetryCount || 0) >= 3) return;
+        if ((task.hasLyric === true || task.hasLyric === false) || (task.lyricRetryCount || 0) >= 3) return;
 
         try {
             // 记录重试次数
             task.lyricRetryCount = (task.lyricRetryCount || 0) + 1;
 
-            const song = task.song;
-            const songId = song.songmid || song.songId || song.id;
-            const url = `/api/music/cache/lyric?source=${song.source}&songmid=${song.songmid || ''}&songId=${song.id || ''}`;
+            const song = task.song || {};
+            const meta = song.meta || {};
+            const source = song.source || meta.source || '';
+            const songmid = song.songmid || song.songId || meta.songmid || meta.songId || song.id || '';
+            const songId = song.id || song.songId || meta.songId || songmid;
+            const url = `/api/music/cache/lyric?source=${encodeURIComponent(source)}&songmid=${encodeURIComponent(songmid)}&songId=${encodeURIComponent(songId || '')}&name=${encodeURIComponent(song.name || meta.songName || '')}&singer=${encodeURIComponent(song.singer || meta.singerName || '')}`;
 
             // [修复] 补全认证请求头
             const headers = {
@@ -411,6 +414,7 @@ class DownloadManager {
                     url: rawUrl, 
                     quality, 
                     enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false,
+                    cacheLyric: window.settings?.enableServerLyricCache !== false,
                     embedLyric: !!(window.settings?.embedLyricToFile ?? true)
                 })
             });
@@ -725,7 +729,7 @@ class DownloadManager {
                     const res = await fetch('/api/music/cache/download', {
                         method: 'POST',
                         headers,
-                        body: JSON.stringify({ songInfo: task.song, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false })
+                        body: JSON.stringify({ songInfo: task.song, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false, cacheLyric: window.settings?.enableServerLyricCache !== false, embedLyric: !!(window.settings?.embedLyricToFile ?? true) })
                     });
                     if (!res.ok) throw new Error('服务器拒绝请求');
 
@@ -829,7 +833,7 @@ class DownloadManager {
                         const res = await fetch('/api/music/cache/download', {
                             method: 'POST',
                             headers,
-                            body: JSON.stringify({ songInfo: t.song, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false })
+                            body: JSON.stringify({ songInfo: t.song, url: rawUrl, quality, enableOnlyDownloadMode: window.settings?.enableOnlyDownloadMode || false, cacheLyric: window.settings?.enableServerLyricCache !== false, embedLyric: !!(window.settings?.embedLyricToFile ?? true) })
                         });
                         if (!res.ok) throw new Error('服务器拒绝缓存');
 

--- a/public/music/js/single_song_ops.js
+++ b/public/music/js/single_song_ops.js
@@ -103,12 +103,20 @@ async function requestServerLyricCache(song, quality = null, force = false) {
 
     console.log(`[Lyric] 尝试同步下载歌词缓存: ${song.name} (${quality || 'auto'})`);
     try {
-        const source = song.source;
-        const songmid = song.songmid;
-        const name = encodeURIComponent(song.name);
-        const singer = encodeURIComponent(song.singer);
-        const hash = song.hash || '';
-        const interval = song.interval || '';
+        const meta = song.meta || {};
+        const source = song.source || meta.source || '';
+        const songmid = song.songmid || song.songId || meta.songmid || meta.songId || song.id || '';
+        const nameValue = song.name || meta.songName || '';
+        const singerValue = song.singer || meta.singerName || '';
+        const name = encodeURIComponent(nameValue);
+        const singer = encodeURIComponent(singerValue);
+        const hash = song.hash || meta.hash || '';
+        const interval = song.interval || meta.interval || '';
+
+        if (!source || !songmid) {
+            console.warn('[Lyric] 歌曲缺少必要字段，跳过歌词缓存同步:', song);
+            return;
+        }
 
         // 1. 先尝试获取歌词数据
         const lyricUrl = `/api/music/lyric?source=${source}&songmid=${songmid}&name=${name}&singer=${singer}&hash=${hash}&interval=${interval}`;
@@ -126,7 +134,16 @@ async function requestServerLyricCache(song, quality = null, force = false) {
         };
 
         // 构建包含音质信息的 songInfo
-        const songInfoForCache = { ...song };
+        const songInfoForCache = {
+            ...song,
+            source,
+            songmid,
+            songId: song.songId || meta.songId || songmid,
+            name: nameValue,
+            singer: singerValue,
+            hash,
+            interval
+        };
         if (quality) songInfoForCache.quality = quality;
 
         const enableOnlyDownloadMode = window.settings?.enableOnlyDownloadMode || false;

--- a/src/server/fileCache.ts
+++ b/src/server/fileCache.ts
@@ -1239,7 +1239,7 @@ export const saveLyricCache = (songInfo: any, lyricsObj: any, username?: string,
     }
 }
 
-export const downloadAndCache = async (songInfo: any, url: string, quality?: string, username?: string, signal?: AbortSignal, isOnlyDownload?: boolean, shouldEmbedLyric: boolean = true) => {
+export const downloadAndCache = async (songInfo: any, url: string, quality?: string, username?: string, signal?: AbortSignal, isOnlyDownload?: boolean, shouldCacheLyric: boolean = true, shouldEmbedLyric: boolean = true) => {
     const dir = ensureDir(username, isOnlyDownload)
     const baseName = getFileName(songInfo, quality, isOnlyDownload, username)
     const tempPath = path.join(dir, baseName + '.tmp')
@@ -1368,22 +1368,29 @@ export const downloadAndCache = async (songInfo: any, url: string, quality?: str
                         tagger.dispose()
                     } catch (e) { }
 
-                    // [新增] 嵌入歌词 USLT 标签（根据 shouldEmbedLyric 判断）
-                    if (shouldEmbedLyric && _lyricFetcher) {
+                    if ((shouldCacheLyric || shouldEmbedLyric) && _lyricFetcher) {
                         try {
                             const lyricText = await _lyricFetcher({ ...songInfo, quality })
                             if (lyricText) {
-                                const tagger2 = new MusicTagger()
-                                tagger2.loadPath(finalPath)
-                                tagger2.lyrics = lyricText
-                                tagger2.save()
-                                tagger2.dispose()
-                                console.log(`[FileCache] USLT lyric embedded for: ${metadata.name}`)
-                                // [新增] 同步更新索引中的 hasEmbedLyric 状态
-                                const finalItem = indexManager.get(normalizedUsername, id, folderType, quality || 'unknown')
-                                if (finalItem) { (finalItem as any).hasEmbedLyric = true }
+                                const lyricsObj = parseLyrics(lyricText)
+                                if (shouldCacheLyric) {
+                                    saveLyricCache({ ...songInfo, quality }, lyricsObj, username, isOnlyDownload)
+                                }
+                                if (shouldEmbedLyric) {
+                                    const tagger2 = new MusicTagger()
+                                    tagger2.loadPath(finalPath)
+                                    tagger2.lyrics = lyricText
+                                    tagger2.save()
+                                    tagger2.dispose()
+                                    console.log(`[FileCache] USLT lyric embedded for: ${metadata.name}`)
+                                    const finalItem = indexManager.get(normalizedUsername, id, folderType, quality || 'unknown')
+                                    if (finalItem) {
+                                        ;(finalItem as any).hasEmbedLyric = true
+                                        indexManager.save(normalizedUsername, folderType)
+                                    }
+                                }
                             }
-                        } catch (e) { /* 歌词写入失败不影响缓存结果 */ }
+                        } catch (e) { /* Lyric cache/embed failure must not fail the audio cache. */ }
                     }
 
                     cacheProgress.set(songKey, { progress: 100, status: 'finished' })
@@ -1894,4 +1901,3 @@ export const categorizeFiles = async (filenames: string[], targetSubPath: string
     indexManager.save(normalizedUsername, folder)
     return { successCount, failCount }
 }
-

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2329,7 +2329,7 @@ const handleStartServer = async (port = 9527, ip = '127.0.0.1') => await new Pro
       if (pathname === '/api/music/cache/download' && req.method === 'POST') {
         void readBody(req).then(body => {
           try {
-            const { songInfo, url, quality, enableOnlyDownloadMode, embedLyric } = JSON.parse(body)
+            const { songInfo, url, quality, enableOnlyDownloadMode, cacheLyric, embedLyric } = JSON.parse(body)
             if (!songInfo || !url) {
               res.writeHead(400)
               res.end('Missing params')
@@ -2362,7 +2362,7 @@ const handleStartServer = async (port = 9527, ip = '127.0.0.1') => await new Pro
             }
             userTasks.push({ songKey, controller })
 
-            void fileCache.downloadAndCache(songInfo, url, quality, username, controller.signal, !!enableOnlyDownloadMode, embedLyric !== false)
+            void fileCache.downloadAndCache(songInfo, url, quality, username, controller.signal, !!enableOnlyDownloadMode, cacheLyric !== false, embedLyric !== false)
               .then(() => console.log(`[Cache] Downloaded ${songInfo.name} for ${username || '_open'}`))
               .catch((err: any) => {
                 if (err.message === 'Aborted') {


### PR DESCRIPTION
## 📝 修改描述 (Description)

<!-- 请简要描述你修复的 Bug 或添加的功能 -->
修复了直接下载歌曲时，不会自动下载歌词，只会显示检测歌词的的bug

## 🆎 修改类型 (Type of Change)

- [ ] 🐛 Bug 修复 (Fix)


## ✅ 提交前检查清单 (Checklist)

**在提交之前，请确保你完成了以下步骤：**

- [ ] 我已将代码合并到了 **`dev`** 分支，而不是 `main`。

## 📸 截图 (Screenshots - 可选)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control to cache lyrics separately from embedding them in audio files.

* **Bug Fixes**
  * Improved lyric detection with more defensive parameter handling and fallback values.
  * Limited lyric operation retries to maximum of 3 attempts to prevent excessive requests.
  * Enhanced error resilience so lyric failures don't block audio file downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->