### PR TITLE
fix: persist valid download concurrency setting

### DIFF
--- a/public/music/app.js
+++ b/public/music/app.js
@@ -74,7 +74,7 @@ const DEFAULT_SETTINGS = {
     enableCustomProxy: false, // 是否启用自定义代理
     customProxyUrl: '', // 自定义代理URL模板，使用 {url} 作为原始URL占位符
     enableOnlyDownloadMode: false, // 仅下载模式
-    downloadConcurrency: 3, // 缓存并发量 (1-6)
+    downloadConcurrency: 3, // 缓存并发量 (1-5)
     hotSearchLimit: 20, // 热搜显示数量
     lyricFontSize: 1.25, // 歌词字体大小 (rem)
     lyricFontFamily: '', // 词字体
@@ -5156,9 +5156,10 @@ const SETTINGS_UI_MAP = {
     downloadConcurrency: {
         id: 'setting-download-concurrency',
         type: 'value',
+        normalize: (v) => Math.min(5, Math.max(1, parseInt(v, 10) || DEFAULT_SETTINGS.downloadConcurrency)),
         action: (v) => {
             if (window.SystemDownloadManager) {
-                window.SystemDownloadManager.updateMaxConcurrent(parseInt(v));
+                window.SystemDownloadManager.updateMaxConcurrent(v);
             }
         }
     },
@@ -5309,6 +5310,7 @@ function syncSettingsUI(key = null, value = null) {
         const config = SETTINGS_UI_MAP[itemKey];
         if (!config) return;
 
+        if (config.normalize) itemValue = config.normalize(itemValue);
         const el = document.getElementById(config.id);
         if (el) {
             if (config.type === 'checkbox') el.checked = !!itemValue;
@@ -12308,5 +12310,4 @@ document.addEventListener('click', (e) => {
 document.addEventListener('DOMContentLoaded', () => {
     window.CustomSelectManager.initAll();
 });
-
 

--- a/public/music/index.html
+++ b/public/music/index.html
@@ -1562,13 +1562,13 @@
                                                 </span>
                                             </div>
                                         </div>
-                                        <select id="setting-download-concurrency" class="lm-select !w-20 !py-1">
+                                        <select id="setting-download-concurrency" class="lm-select !w-20 !py-1"
+                                            onchange="updateSetting('downloadConcurrency', parseInt(this.value))">
                                             <option value="1">1</option>
                                             <option value="2">2</option>
-                                            <option value="3">3</option>
+                                            <option value="3" selected>3</option>
                                             <option value="4">4</option>
                                             <option value="5">5</option>
-                                            <option value="6">6</option>
                                         </select>
                                     </div>
                                 </div>

--- a/public/music/js/download_manager.js
+++ b/public/music/js/download_manager.js
@@ -6,7 +6,7 @@
 class DownloadManager {
     constructor() {
         this.tasks = []; // Queue of tasks
-        this.maxConcurrent = window.settings?.downloadConcurrency || 3;
+        this.maxConcurrent = this.normalizeConcurrency(window.settings?.downloadConcurrency);
         this.activeCount = 0; // Currently active (local downloading + triggered server tasks)
 
         // UI Elements
@@ -29,9 +29,15 @@ class DownloadManager {
 
     // Update max concurrency limit dynamically
     updateMaxConcurrent(value) {
-        console.log('[DownloadManager] Concurrency limit updated to:', value);
-        this.maxConcurrent = value;
+        this.maxConcurrent = this.normalizeConcurrency(value);
+        console.log('[DownloadManager] Concurrency limit updated to:', this.maxConcurrent);
         this.processQueue();
+    }
+
+    normalizeConcurrency(value) {
+        const parsed = parseInt(value, 10);
+        if (!Number.isFinite(parsed)) return 3;
+        return Math.min(5, Math.max(1, parsed));
     }
 
     async pollServerProgress() {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1802,7 +1802,7 @@ const handleStartServer = async (port = 9527, ip = '127.0.0.1') => await new Pro
             // [核心逻辑] 如果是受限的公开用户，仅允许保存特定的 3 项设置
             if (resolvedUsername === '_open' && global.lx.config['user.enablePublicRestriction']) {
               const restrictedSettings: any = {}
-              const allowedKeys = ['enableServerCache', 'enableServerLyricCache', 'serverCacheLocation']
+              const allowedKeys = ['enableServerCache', 'enableServerLyricCache', 'serverCacheLocation', 'downloadConcurrency']
               allowedKeys.forEach(key => {
                 if (settings[key] !== undefined) restrictedSettings[key] = settings[key]
               })


### PR DESCRIPTION
## 📝 修改描述 (Description)

<!-- 请简要描述你修复的 Bug 或添加的功能 -->
修复了下载并发量修改无效的bug，并且测试了并发量为6时，ui会卡死，建议删除并发量为6。

## 🆎 修改类型 (Type of Change)

- [ ] 🐛 Bug 修复 (Fix)


## ✅ 提交前检查清单 (Checklist)

**在提交之前，请确保你完成了以下步骤：**

- [ ] 我已将代码合并到了 **`dev`** 分支，而不是 `main`。


## 📸 截图 (Screenshots - 可选)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Public users can now save and persist their download concurrency preferences.

* **Bug Fixes**
  * Refined download concurrency handling with improved validation: supported range is now 1–5 (previously 1–6) with automatic value normalization and clamping.
  * Default download concurrency value set to 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->