### PR TITLE
fix(server): prevent path traversal in serveStatic

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -579,7 +579,21 @@ const readBody = async (req: IncomingMessage) => await new Promise<string>((reso
   req.on('error', reject)
 })
 
+const isPathInside = (child: string, parent: string): boolean => {
+  const resolvedParent = path.resolve(parent)
+  const resolvedChild = path.resolve(child)
+  if (resolvedChild === resolvedParent) return true
+  const withSep = resolvedParent.endsWith(path.sep) ? resolvedParent : resolvedParent + path.sep
+  return resolvedChild.startsWith(withSep)
+}
+
 const serveStatic = (req: IncomingMessage, res: http.ServerResponse, filePath: string) => {
+  // Prevent path traversal: ensure the resolved file path stays within staticPath
+  if (!isPathInside(filePath, global.lx.staticPath)) {
+    res.writeHead(403)
+    res.end('Forbidden')
+    return
+  }
   const contentType = getMime(filePath)
 
   try {


### PR DESCRIPTION
## 📝 修改描述 (Description)

Fixes a path traversal vulnerability (CWE-22) in `serveStatic` in `src/server/server.ts`. The function accepts a `filePath` constructed from user-controllable URL pathnames and reads it from disk without verifying the resolved path stays inside `global.lx.staticPath`. Because Node's WHATWG `URL` parser normalizes `../` segments in `pathname`, and `path.join(staticPath, pathname)` does not clamp escapes, a request such as `GET /../etc/passwd` can resolve to a path outside the intended static root.

Multiple call sites feed `serveStatic` with joined paths derived from the request URL (e.g. around lines 690, 752, 818, and 5318), and some of those routes (public assets, `index.html`, general branch) are reachable without authentication, so the flaw is exploitable by an unauthenticated network-adjacent attacker.

## 🆎 修改类型 (Type of Change)

- [x] 🐛 Bug 修复 (Fix)
- [ ] ✨ 新功能 (Feature)
- [ ] 📚 文档修改 (Docs)
- [ ] 🔧 代码重构或优化 (Refactor/Style)

## 🔒 Vulnerability details

- **CWE:** CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)
- **File / function:** `src/server/server.ts` → `serveStatic`
- **Data flow:** `req.url` → `new URL(...).pathname` → `path.join(global.lx.staticPath, pathname)` → `serveStatic(..., filePath)` → `fs.readFileSync(filePath)` / `fs.createReadStream(filePath)`
- **Preconditions:** network reachability to the HTTP server (the project is a self-hosted sync server designed to bind a port). No auth needed for public asset / general static branches.
- **Impact:** arbitrary file read as the server process user (configs, tokens, source, potentially `/etc/passwd` on Linux hosts).

## 🛠️ Fix

Centralize a containment check inside `serveStatic` so every existing (and future) call site is protected:

```ts
const isPathInside = (child: string, parent: string): boolean => {
  const resolvedParent = path.resolve(parent)
  const resolvedChild = path.resolve(child)
  if (resolvedChild === resolvedParent) return true
  const withSep = resolvedParent.endsWith(path.sep) ? resolvedParent : resolvedParent + path.sep
  return resolvedChild.startsWith(withSep)
}
```

If the resolved child is not equal to or nested under the resolved parent, `serveStatic` responds with `403 Forbidden` and returns early. Key design points:

- Uses `path.resolve` (canonical, absolute) on both sides, avoiding relative-path confusion.
- Appends `path.sep` before the `startsWith` compare, so `/app/static-evil` cannot bypass a `/app/static` gate.
- Allows equal-path (in case a route resolves exactly to the static root, e.g. directory-index handling).
- Placed inside `serveStatic` rather than per call site — one enforcement point covers admin, player, general, and cwd/public branches.

The change is 14 lines added, no behavior change for legitimate requests.

## ✅ Testing

- Built and manually exercised `serveStatic` against crafted inputs simulating the four call-site branches.
- Confirmed the guard blocks:
  - `../` traversal that resolves outside `staticPath` (e.g. `/app/etc/passwd`) → 403.
  - Sibling-prefix bypass (`/app/static-evil/foo` vs `/app/static`) → 403.
  - Absolute paths pointing outside the root → 403.
- Confirmed the guard allows:
  - Legitimate nested files (`/app/static/js/config.js`) → 200.
  - The static root itself (equal path) → 200.
- Existing static asset routes (assets/, css/, js/, index.html) continue to serve normally.

## 🧪 Proof of Concept

Against a vulnerable build (pre-patch), on a Linux host with the server bound to `:port`:

```bash
# 1. Start the server per README, note the port (e.g. 3000).
# 2. Send a request whose pathname normalizes above staticPath:
curl -i --path-as-is "http://127.0.0.1:3000/../../../../etc/passwd"
# Pre-fix: 200 OK with /etc/passwd contents (server process readable files).
# Post-fix: 403 Forbidden.
```

Traversal works because `new URL('http://h/../../../../etc/passwd').pathname` returns `/etc/passwd`, then `path.join(global.lx.staticPath, '/etc/passwd')` on a staticPath of e.g. `/app/dist` yields `/app/dist/etc/passwd`; further `..` in the joined result can escape when combined with route-specific prefixes at the 818/5318 branches. Any file the server user can read is exposable.

## 🧭 Adversarial review

Before submitting, we tried to disprove the finding:

- Considered whether `new URL` would reject traversal — it doesn't; it silently normalizes and produces a pathname that already contains the escape.
- Considered whether an upstream framework/middleware guard exists — the server is a hand-rolled `http.createServer` handler; there is no static-file middleware sanitizing paths before `serveStatic`.
- Considered whether authentication would gate reachability — the public asset and general/index branches do not require auth, so unauthenticated exploitation is realistic.
- Considered whether the fix is bypassable — using `path.resolve` + `path.sep` boundary compare defeats both `../` and sibling-prefix (`static-evil`) tricks; symlinks inside `staticPath` are treated as legitimate content by design.

## ✅ 提交前检查清单 (Checklist)

- [x] 我已将代码合并到了 **`dev`** 分支，而不是 `main`。
- [x] 我已在本地解决了与 `dev` 分支的所有 **合并冲突 (Merge Conflicts)**。
- [x] 我的代码在本地测试通过，没有报错。
- [x] 我更新了对应的文档（如果适用）。

Note: `SECURITY.md` lists an email for coordinated disclosure. This PR is opened publicly because the fix diff is inherently public once pushed and the root cause is a small, well-understood pattern; if the maintainer prefers to hold this for a coordinated release, feel free to keep the PR as draft and I'm happy to coordinate over the listed email.