### PR TITLE
fix(discovery): remove hardcoded QQ Music session cookies (CWE-798)

### DIFF
--- a/src/server/utils/discovery.ts
+++ b/src/server/utils/discovery.ts
@@ -13,7 +13,7 @@ const PLAYLIST_DETAIL_URL = 'https://c.y.qq.com/qzone/fcg-bin/fcg_ucc_getcdinfo_
 const commonHeaders = {
     'Referer': 'https://y.qq.com/',
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-    'Cookie': `RK=mLRriRA13K; ptcz=273c2bb24bc85618bd0a879535807143171987c59496dc7f98b933f2d48c8b51; pgv_pvid=6071629980; fqm_pvqid=73ba6d20-4755-4f67-b42b-112630e9c681; ts_uid=8621614784; music_ignore_pskey=202306271436Hn@vBj; fqm_sessionid=646002fc-0ee6-4755-a084-0c8dddbc6345; pgv_info=ssid=s4176822120; ts_last=y.qq.com/; ts_refer=ADTAGmyqq; _qpsvr_localtk=0.8864745738532814; login_type=1; qm_keyst=Q_H_L_63k3NvhdYrRrdgZjY8lw3j8O2Da7uybs72Lk1CAOPzGJIGAL3KIk2vkkry4WV8BYf31jeSZDUTvufx7QO7C7XMJk7eYoqNA; psrf_qqrefresh_token=29230BD8C6D560C4419C859E1137769A; tmeLoginType=2; wxopenid=; psrf_musickey_createtime=1776444390; psrf_qqopenid=528AB084D4E36B8B2011FD9035F3754B; euin=owvz7wvqNeSz7n**; wxunionid=; psrf_qqunionid=713D2E77AEDDB79B60EB9160532A5A54; qqmusic_key=Q_H_L_63k3NvhdYrRrdgZjY8lw3j8O2Da7uybs72Lk1CAOPzGJIGAL3KIk2vkkry4WV8BYf31jeSZDUTvufx7QO7C7XMJk7eYoqNA; psrf_qqaccess_token=837B4E69CE720B2D44B38B59B41CB637; wxrefresh_token=; psrf_access_token_expiresAt=1781628390; uin=2406498704`
+    'Cookie': process.env.QQ_MUSIC_COOKIE || ''
 }
 
 /**


### PR DESCRIPTION
## 📝 修改描述 (Description)

Removes hardcoded QQ Music user session cookies from `src/server/utils/discovery.ts` and sources them from an environment variable instead. This is a **CWE-798: Use of Hard-coded Credentials** issue — a real, logged-in QQ Music session (including `qqmusic_key`, `psrf_qqaccess_token`, `psrf_qqrefresh_token`, and `uin=2406498704`) was committed to this public repository and shipped with the discovery module.

## 🆎 修改类型 (Type of Change)

- [x] 🐛 Bug 修复 (Fix) — security

## ✅ 提交前检查清单 (Checklist)

- [x] Targets the **`dev`** branch (per CONTRIBUTING.md).
- [x] Rebased on latest `dev`, no merge conflicts.
- [x] Change is minimal (1 line) and does not alter public behavior beyond the credential source.
- [x] No new dependencies.

---

## Vulnerability details

- **File:** `src/server/utils/discovery.ts`, line 16 (the `commonHeaders.Cookie` field used by both `DISCOVERY_URL` and `PLAYLIST_DETAIL_URL` requests to `c.y.qq.com`).
- **Class:** CWE-798 — Use of Hard-coded Credentials.
- **What leaked:** A complete, authenticated QQ Music session cookie string containing `qqmusic_key`, `psrf_qqaccess_token`, `psrf_qqrefresh_token`, `uin=2406498704` (a real QQ user ID), and `psrf_access_token_expiresAt=1781628390` (valid well into the future).
- **Exposure:** the repository is public, has releases and download stats — anyone who has cloned or forked it already possesses the credentials. GitHub code search, grep.app, sourcegraph and similar indexers surface this file.

## Fix

```ts
- 'Cookie': `RK=...; qqmusic_key=...; uin=2406498704`
+ 'Cookie': process.env.QQ_MUSIC_COOKIE || ''
```

Minimal, backward-compatible for anyone running the server with `QQ_MUSIC_COOKIE` set. If the variable is unset the request goes out with an empty `Cookie` header, which the QQ endpoints handle the same way they handle any unauthenticated request — no crashes, no behavior regressions beyond what an unauthenticated call already does.

## Follow-up actions (out of scope for this PR, but important)

This PR only removes the secret from **current source**. To fully close out the incident, the maintainer will also need to:

1. **Revoke the leaked session** — log the affected QQ Music account out of all sessions (QQ Music → Settings → Login Devices → Sign out everywhere) and rotate the password. Until this is done, anyone with the git history can still act as the account.
2. **Purge from git history** if desired (`git filter-repo` or BFG). Even after purging, the secret must be treated as compromised because it has already been public.

I would normally raise credential leaks like this privately, but this repo has no GitHub Security Advisories enabled and no `security@` contact — and the credential is already public in `main`, so private disclosure would not reduce exposure. Publishing the fix here is the fastest way to shorten the window.

## How to reproduce

```bash
git clone https://github.com/XCQ0607/lxserver
grep -n 'qqmusic_key' lxserver/src/server/utils/discovery.ts
# → prints the full authenticated QQ Music session cookie
```

An attacker can then replay the `Cookie` header against `https://c.y.qq.com/` endpoints to act as the account holder (read private playlists, favorites, listening history; some endpoints also permit modifying playlists depending on the token's scope).

## Verification of this patch

- `grep -rn 'qqmusic_key\|psrf_qqaccess_token\|uin=2406498704' src/` — no matches after the patch.
- `grep -rn 'Cookie' src/server/utils/` — the only remaining `Cookie` header assignment is the `process.env.QQ_MUSIC_COOKIE || ''` line.
- The change is a single line inside one object literal; TypeScript typing is unaffected (`string` → `string`).
- Diff against `dev` is exactly 1 file / 1 line changed.

## Adversarial review

Before submitting I tried to disprove this: could the cookie be a throwaway/demo account (making it non-sensitive), or is authentication actually unnecessary here so the header is decorative? Neither holds. The cookie contains a real `uin`, non-empty refresh + access tokens, and a `qqmusic_key` — the presence of `psrf_qqrefresh_token` in particular means the session can be silently extended, so simple expiry does not close the window. And the header is clearly load-bearing: it's applied to both discovery and playlist-detail requests, which return account-scoped data. No framework-level auth wrapper or `.env`-loading indirection was hiding a safer code path — the literal was the only source. That's why this warrants a fix rather than a docs note.