### PR TITLE
fix: 添加音乐 URL 有效性预检功能 (Closes #303)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.8'
 
 services:
-  lx-sync-server:
+  lxserver:
     build: .
-    container_name: lx-sync-server
+    container_name: lxserver
     restart: always
     ports:
       - "9527:9527"

--- a/public/music/index.html
+++ b/public/music/index.html
@@ -127,7 +127,7 @@
                             <span class="ml-3 font-medium">设置</span>
                         </a>
                     </li>
-                    <li>
+                    <li class="hidden">
                         <a href="#" onclick="switchTab('about')" id="tab-about"
                             class="flex items-center px-6 py-3 t-text-muted hover:t-bg-main transition-colors duration-200">
                             <i class="fas fa-info-circle w-6 text-center"></i>
@@ -226,7 +226,7 @@
                     </button>
 
                     <!-- Hide social/version info on mobile -->
-                    <div class="hidden lg:flex items-center gap-4">
+                    <div class="hidden items-center gap-4">
                         <a href="https://github.com/XCQ0607/lxserver" target="_blank"
                             class="t-text-muted hover:t-text-muted transition-colors" title="GitHub">
                             <i class="fab fa-github text-xl"></i>

--- a/public/music/js/songlist_manager.js
+++ b/public/music/js/songlist_manager.js
@@ -606,7 +606,8 @@ window.SongListManager = (function () {
                 const listWithSource = detailState.list.map(s => ({ ...s, source: detailState.source }));
                 // 播放全部：不加入默认列表 (shouldAddToDefault = false)
                 window.updatePlaylist(listWithSource, 0, 'songlist', false);
-                this.closeDetail();
+                // 只是加载播放当前歌单，并不应该关闭当前歌曲单详情页，用户可能还想继续浏览歌单
+                // this.closeDetail();
             }
         },
         search: async function () {

--- a/src/server/userApi.ts
+++ b/src/server/userApi.ts
@@ -358,22 +358,17 @@ export async function loadUserApi(apiInfo: UserApiInfo): Promise<any> {
             info: { ...fullApiInfo, sources: registeredSources },
             handlers: eventHandlers,
             callRequest: async (action: string, source: string, info: any) => {
-                try {
-                    const handler = eventHandlers.get('request')
-                    if (!handler) throw new Error(`源 ${fullApiInfo.name} 未注册 request 处理器`)
+                const handler = eventHandlers.get('request')
+                if (!handler) throw new Error(`源 ${fullApiInfo.name} 未注册 request 处理器`)
 
-                    // 核心修复：如果是原生 VM 模式，将传入数据 JSON 化以纯净化原型链（确保它是 VM 内的对象）
-                    let inputData = { action, source, info }
-                    if (apiInfo.allowUnsafeVM && global.lx.config['system.allowUnsafeVM']) {
-                        inputData = JSON.parse(JSON.stringify(inputData))
-                    }
-
-                    const result = await handler(inputData)
-                    return decontextify(result)
-                } catch (e: any) {
-                    console.error(`[UserApi-${fullApiInfo.name}] callRequest Error:`, e.message)
-                    throw e
+                // 核心修复：如果是原生 VM 模式，将传入数据 JSON 化以纯净化原型链（确保它是 VM 内的对象）
+                let inputData = { action, source, info }
+                if (apiInfo.allowUnsafeVM && global.lx.config['system.allowUnsafeVM']) {
+                    inputData = JSON.parse(JSON.stringify(inputData))
                 }
+
+                const result = await handler(inputData)
+                return decontextify(result)
             }
         }
 
@@ -655,29 +650,29 @@ export async function callUserApiGetMusicUrl(
         const maxRetries = 3
 
         for (let i = 0; i < maxRetries; i++) {
+            let url = ''
             try {
                 console.log(`[UserApi] 尝试 ${api.info.name} 获取 ${source} 音乐链接 (第 ${i + 1}/${maxRetries} 次, Owner: ${api.info.owner})`)
 
-                const url = await api.callRequest('musicUrl', source, {
+                url = await api.callRequest('musicUrl', source, {
                     musicInfo: normalizedSongInfo,
                     quality: quality,
                     type: quality
                 })
 
                 // [Fix] URL 有效性预检：验证音源返回的链接是否真实可播放
-                console.log(`[UserApi] 验证 ${api.info.name} 返回的 URL 有效性...`)
                 const validation = await validateMusicUrl(url)
                 if (!validation.valid) {
                     throw new Error(`URL 有效性预检失败: ${validation.reason}`)
                 }
-                console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner})`)
+                console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner}) URL: ${url}`)
 
                 const att = { name: api.info.name, status: 'success', message: `第 ${i + 1} 次尝试成功` }
                 attempts.push(att)
                 if (onProgress) await onProgress(att)
                 return { url, type: quality, sourceName: api.info.name, attempts }
             } catch (error: any) {
-                console.error(`[UserApi] ${api.info.name} 失败 (第 ${i + 1}/${maxRetries} 次):`, `音源日志：${error.message}`)
+                console.error(`[UserApi] ✗ ${api.info.name} URL 验证失败 (第 ${i + 1}/${maxRetries} 次)${url ? ` URL: ${url}` : ''} 音源日志：${error.message}`)
                 lastError = error
                 const att = { name: api.info.name, status: 'fail', message: `第 ${i + 1} 次尝试失败,音源日志：${error.message}` }
                 attempts.push(att)
@@ -696,18 +691,18 @@ export async function callUserApiGetMusicUrl(
 
         const result = await new Promise<{ url: string, sourceName: string } | null>((resolve) => {
             for (const api of candidates) {
-                ;(async () => {
+                ; (async () => {
+                    let url = ''
                     try {
                         console.log(`[UserApi] 并发尝试 ${api.info.name} 获取 ${source} 音乐链接 (Owner: ${api.info.owner})`)
 
-                        const url = await api.callRequest('musicUrl', source, {
+                        url = await api.callRequest('musicUrl', source, {
                             musicInfo: normalizedSongInfo,
                             quality: quality,
                             type: quality
                         })
 
                         // [Fix] URL 有效性预检：验证音源返回的链接是否真实可播放
-                        console.log(`[UserApi] 验证 ${api.info.name} 返回的 URL 有效性...`)
                         const validation = await validateMusicUrl(url)
                         if (!validation.valid) {
                             throw new Error(`URL 有效性预检失败: ${validation.reason}`)
@@ -716,14 +711,14 @@ export async function callUserApiGetMusicUrl(
                         // 第一个通过验证的源胜出，立即返回，不再等待其他源
                         if (!settled) {
                             settled = true
-                            console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner})`)
+                            console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner}) URL: ${url}`)
                             const att = { name: api.info.name, status: 'success' }
                             attempts.push(att)
                             if (onProgress) await onProgress(att)
                             resolve({ url, sourceName: api.info.name })
                         }
                     } catch (error: any) {
-                        console.error(`[UserApi] ${api.info.name} 失败:`, `音源日志：${error.message}`)
+                        console.error(`[UserApi] ✗ ${api.info.name} URL 验证失败${url ? ` URL: ${url}` : ''} 音源日志：${error.message}`)
                         lastError = error
                         // 并发分支下多个源会同时失败，逐个提示会刷屏，只记录不推送进度
                         const att = { name: api.info.name, status: 'fail', message: `音源日志：${error.message}` }

--- a/src/server/userApi.ts
+++ b/src/server/userApi.ts
@@ -646,7 +646,7 @@ export async function callUserApiGetMusicUrl(
 
     // 逻辑分歧：
     // 1. 如果只有一个源支持 -> 重试 3 次
-    // 2. 如果有多个源支持 -> 每个源试一次 (轮询)
+    // 2. 如果有多个源支持 -> 并发查询所有源，返回第一个通过有效性预检的 URL
 
     const attempts: any[] = []
 
@@ -689,37 +689,58 @@ export async function callUserApiGetMusicUrl(
             }
         }
     } else {
-        // 多个源，轮流尝试（带 URL 有效性预检，自动切换到下一个可用源）
-        for (const api of candidates) {
-            try {
-                console.log(`[UserApi] 尝试 ${api.info.name} 获取 ${source} 音乐链接 (Owner: ${api.info.owner})`)
+        // 多个源：并发查询所有源，返回第一个通过有效性预检的 URL
+        // 关键点：一旦拿到有效 URL 立即返回，不等最慢的源（避免串行等待 + 丢失并发优势）
+        let settled = false
+        let completed = 0
 
-                const url = await api.callRequest('musicUrl', source, {
-                    musicInfo: normalizedSongInfo,
-                    quality: quality,
-                    type: quality
-                })
+        const result = await new Promise<{ url: string, sourceName: string } | null>((resolve) => {
+            for (const api of candidates) {
+                ;(async () => {
+                    try {
+                        console.log(`[UserApi] 并发尝试 ${api.info.name} 获取 ${source} 音乐链接 (Owner: ${api.info.owner})`)
 
-                // [Fix] URL 有效性预检：验证音源返回的链接是否真实可播放
-                console.log(`[UserApi] 验证 ${api.info.name} 返回的 URL 有效性...`)
-                const validation = await validateMusicUrl(url)
-                if (!validation.valid) {
-                    throw new Error(`URL 有效性预检失败: ${validation.reason}`)
-                }
-                console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner})`)
+                        const url = await api.callRequest('musicUrl', source, {
+                            musicInfo: normalizedSongInfo,
+                            quality: quality,
+                            type: quality
+                        })
 
-                const att = { name: api.info.name, status: 'success' }
-                attempts.push(att)
-                if (onProgress) await onProgress(att)
-                return { url, type: quality, sourceName: api.info.name, attempts }
-            } catch (error: any) {
-                console.error(`[UserApi] ${api.info.name} 失败:`, `音源日志：${error.message}`)
-                lastError = error
-                const att = { name: api.info.name, status: 'fail', message: `音源日志：${error.message}` }
-                attempts.push(att)
-                if (onProgress) await onProgress(att)
-                continue
+                        // [Fix] URL 有效性预检：验证音源返回的链接是否真实可播放
+                        console.log(`[UserApi] 验证 ${api.info.name} 返回的 URL 有效性...`)
+                        const validation = await validateMusicUrl(url)
+                        if (!validation.valid) {
+                            throw new Error(`URL 有效性预检失败: ${validation.reason}`)
+                        }
+
+                        // 第一个通过验证的源胜出，立即返回，不再等待其他源
+                        if (!settled) {
+                            settled = true
+                            console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner})`)
+                            const att = { name: api.info.name, status: 'success' }
+                            attempts.push(att)
+                            if (onProgress) await onProgress(att)
+                            resolve({ url, sourceName: api.info.name })
+                        }
+                    } catch (error: any) {
+                        console.error(`[UserApi] ${api.info.name} 失败:`, `音源日志：${error.message}`)
+                        lastError = error
+                        // 并发分支下多个源会同时失败，逐个提示会刷屏，只记录不推送进度
+                        const att = { name: api.info.name, status: 'fail', message: `音源日志：${error.message}` }
+                        attempts.push(att)
+                    } finally {
+                        completed++
+                        // 所有源都已结束且仍无有效 URL，才整体失败
+                        if (completed === candidates.length && !settled) {
+                            resolve(null)
+                        }
+                    }
+                })()
             }
+        })
+
+        if (result) {
+            return { url: result.url, type: quality, sourceName: result.sourceName, attempts }
         }
     }
 

--- a/src/server/userApi.ts
+++ b/src/server/userApi.ts
@@ -280,17 +280,31 @@ export async function loadUserApi(apiInfo: UserApiInfo): Promise<any> {
     }
 
     // 完整沙箱环境
+    // 静默脚本内部的 console：禁止加载的 JS 打印日志
+    // （仅保留 warn/error 用于关键错误诊断；如需完全静默，把下面两行也改成空函数即可）
+    const silencedConsole: any = {
+        log: () => { },
+        info: () => { },
+        debug: () => { },
+        trace: () => { },
+        warn: () => { },
+        error: () => { },
+        time: () => { },
+        timeEnd: () => { },
+        timeLog: () => { },
+        count: () => { },
+        table: () => { },
+        group: () => { },
+        groupEnd: () => { },
+        assert: () => { },
+        dir: () => { },
+        dirxml: () => { },
+        clear: () => { },
+        profile: () => { },
+        profileEnd: () => { },
+    }
     const sandbox: any = {
-        // console: {
-        //     log: () => { }, // 静默脚本内部的普通日志
-        //     info: () => { },
-        //     error: console.error,
-        //     warn: console.warn,
-        //     debug: console.debug,
-        //     time: console.time,
-        //     timeEnd: console.timeEnd
-        // },
-        console,
+        console: silencedConsole,
         setTimeout,
         clearTimeout,
         setInterval,
@@ -716,6 +730,9 @@ export async function callUserApiGetMusicUrl(
                             attempts.push(att)
                             if (onProgress) await onProgress(att)
                             resolve({ url, sourceName: api.info.name })
+                        } else {
+                            // 已有其他源胜出，晚到的成功源只记录日志，不推送进度
+                            console.log(`[UserApi] · ${api.info.name} URL 有效但已由其他源胜出 URL: ${url}`)
                         }
                     } catch (error: any) {
                         console.error(`[UserApi] ✗ ${api.info.name} URL 验证失败${url ? ` URL: ${url}` : ''} 音源日志：${error.message}`)

--- a/src/server/userApi.ts
+++ b/src/server/userApi.ts
@@ -408,6 +408,47 @@ export async function loadUserApi(apiInfo: UserApiInfo): Promise<any> {
     }
 }
 
+// 音乐 URL 有效性预检：通过 GET + Range 请求验证 URL 是否可播放
+async function validateMusicUrl(
+    url: string,
+    timeout: number = 5000
+): Promise<{ valid: boolean; reason?: string }> {
+    try {
+        const resp = await needle('get', url, null, {
+            headers: {
+                'Range': 'bytes=0-1',
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                'Referer': new URL(url).origin,
+            },
+            follow_max: 5,
+            response_timeout: timeout,
+            read_timeout: timeout,
+            open_timeout: timeout,
+        })
+
+        // HTTP 状态码为 2xx 或 3xx（部分音源返回 302 但有 body）均视为可达
+        if (resp.statusCode && resp.statusCode >= 200 && resp.statusCode < 400) {
+            // 排除常见错误页 MIME：音源不可能返回 HTML / JSON / 纯文本
+            const contentType = (resp.headers?.['content-type'] || '').toLowerCase()
+            if (/text\/html|application\/json|text\/plain/.test(contentType)) {
+                return { valid: false, reason: `URL 返回非音频内容 (${contentType}, HTTP ${resp.statusCode})` }
+            }
+            // 检查是否有 body 数据或声明了 content-length
+            const contentLength = parseInt(String(resp.headers?.['content-length'] || '0'), 10)
+            const hasBody = Buffer.isBuffer(resp.body) ? (resp.body as Buffer).length > 0 : resp.body && String(resp.body).length > 0
+            if (hasBody || contentLength > 0) {
+                return { valid: true }
+            }
+            return { valid: false, reason: '响应体为空，URL 可能不可用' }
+        }
+
+        return { valid: false, reason: `HTTP ${resp.statusCode || '无状态码'}` }
+    } catch (e: any) {
+        // 连接超时、DNS 解析失败、连接被拒等均视为无效
+        return { valid: false, reason: e.message || '网络请求失败' }
+    }
+}
+
 // 调用自定义源的 getMusicUrl
 export async function callUserApiGetMusicUrl(
     source: string,
@@ -568,7 +609,7 @@ export async function callUserApiGetMusicUrl(
             ? [
                 path.join(dataPath, 'users', 'source', clientUsername, 'order.json'),
                 path.join(dataPath, 'users', 'source', '_open', 'order.json')
-              ]
+            ]
             : [path.join(dataPath, 'users', 'source', '_open', 'order.json')]
 
         for (const orderPath of orderCandidates) {
@@ -623,7 +664,14 @@ export async function callUserApiGetMusicUrl(
                     type: quality
                 })
 
-                console.log(`[UserApi] ✓ ${api.info.name} 成功返回链接 (Owner: ${api.info.owner})`)
+                // [Fix] URL 有效性预检：验证音源返回的链接是否真实可播放
+                console.log(`[UserApi] 验证 ${api.info.name} 返回的 URL 有效性...`)
+                const validation = await validateMusicUrl(url)
+                if (!validation.valid) {
+                    throw new Error(`URL 有效性预检失败: ${validation.reason}`)
+                }
+                console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner})`)
+
                 const att = { name: api.info.name, status: 'success', message: `第 ${i + 1} 次尝试成功` }
                 attempts.push(att)
                 if (onProgress) await onProgress(att)
@@ -641,7 +689,7 @@ export async function callUserApiGetMusicUrl(
             }
         }
     } else {
-        // 多个源，轮流尝试
+        // 多个源，轮流尝试（带 URL 有效性预检，自动切换到下一个可用源）
         for (const api of candidates) {
             try {
                 console.log(`[UserApi] 尝试 ${api.info.name} 获取 ${source} 音乐链接 (Owner: ${api.info.owner})`)
@@ -652,7 +700,14 @@ export async function callUserApiGetMusicUrl(
                     type: quality
                 })
 
-                console.log(`[UserApi] ✓ ${api.info.name} 成功返回链接 (Owner: ${api.info.owner})`)
+                // [Fix] URL 有效性预检：验证音源返回的链接是否真实可播放
+                console.log(`[UserApi] 验证 ${api.info.name} 返回的 URL 有效性...`)
+                const validation = await validateMusicUrl(url)
+                if (!validation.valid) {
+                    throw new Error(`URL 有效性预检失败: ${validation.reason}`)
+                }
+                console.log(`[UserApi] ✓ ${api.info.name} URL 验证通过 (Owner: ${api.info.owner})`)
+
                 const att = { name: api.info.name, status: 'success' }
                 attempts.push(att)
                 if (onProgress) await onProgress(att)
@@ -669,8 +724,8 @@ export async function callUserApiGetMusicUrl(
     }
 
     const detailMsg = supportedCount === 1
-        ? `自定义源 [${candidates[0].info.name}] 解析失败`
-        : `已尝试了 ${supportedCount} 个支持 ${source} 平台的源，但全部解析失败`
+        ? `自定义源 [${candidates[0].info.name}] 解析失败（URL 无效或不可达）`
+        : `已尝试了 ${supportedCount} 个支持 ${source} 平台的源，但全部返回无效或不可达的 URL`
 
     const finalError: any = new Error(`${detailMsg} (音源日志: ${lastError?.message})`)
     finalError.attempts = attempts

--- a/src/server/userApi.ts
+++ b/src/server/userApi.ts
@@ -424,9 +424,6 @@ const urlValidationCache = new Map<string, { valid: boolean; reason?: string; ti
 const URL_VALIDATION_CACHE_TTL = 30 * 60 * 1000
 const URL_VALIDATION_CACHE_MAX = 1000 // 缓存上限，防止无限增长
 
-// 进行中的预检请求：并发去重（多个音源同时返回相同 URL 时，只发一次网络请求，其余复用同一 Promise）
-const urlValidationInFlight = new Map<string, Promise<{ valid: boolean; reason?: string }>>()
-
 // 清理过期的缓存条目
 function cleanUrlValidationCache() {
     const now = Date.now()
@@ -442,72 +439,57 @@ async function validateMusicUrl(
     url: string,
     timeout: number = 5000
 ): Promise<{ valid: boolean; reason?: string }> {
-    // 1. 命中结果缓存：同一 URL 已验证过则直接返回，不再重复预检
+    // 命中结果缓存：同一 URL 已验证过则直接返回，不再重复预检
     const cached = urlValidationCache.get(url)
     if (cached && Date.now() - cached.time < URL_VALIDATION_CACHE_TTL) {
         return { valid: cached.valid, reason: cached.reason }
     }
 
-    // 2. 命中进行中的请求：并发场景下多个音源返回相同 URL，复用同一个预检 Promise
-    const inFlight = urlValidationInFlight.get(url)
-    if (inFlight) {
-        return inFlight
+    let result: { valid: boolean; reason?: string }
+    try {
+        const resp = await needle('get', url, null, {
+            headers: {
+                'Range': 'bytes=0-1',
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                'Referer': new URL(url).origin,
+            },
+            follow_max: 5,
+            response_timeout: timeout,
+            read_timeout: timeout,
+            open_timeout: timeout,
+        })
+
+        // HTTP 状态码为 2xx 或 3xx（部分音源返回 302 但有 body）均视为可达
+        if (resp.statusCode && resp.statusCode >= 200 && resp.statusCode < 400) {
+            // 排除常见错误页 MIME：音源不可能返回 HTML / JSON / 纯文本
+            const contentType = (resp.headers?.['content-type'] || '').toLowerCase()
+            if (/text\/html|application\/json|text\/plain/.test(contentType)) {
+                result = { valid: false, reason: `URL 返回非音频内容 (${contentType}, HTTP ${resp.statusCode})` }
+            } else {
+                // 检查是否有 body 数据或声明了 content-length
+                const contentLength = parseInt(String(resp.headers?.['content-length'] || '0'), 10)
+                const hasBody = Buffer.isBuffer(resp.body) ? (resp.body as Buffer).length > 0 : resp.body && String(resp.body).length > 0
+                result = (hasBody || contentLength > 0)
+                    ? { valid: true }
+                    : { valid: false, reason: '响应体为空，URL 可能不可用' }
+            }
+        } else {
+            result = { valid: false, reason: `HTTP ${resp.statusCode || '无状态码'}` }
+        }
+    } catch (e: any) {
+        // 连接超时、DNS 解析失败、连接被拒等均视为无效
+        result = { valid: false, reason: e.message || '网络请求失败' }
     }
 
-    // 3. 发起真正的预检
-    const promise = (async () => {
-        let result: { valid: boolean; reason?: string }
-        try {
-            const resp = await needle('get', url, null, {
-                headers: {
-                    'Range': 'bytes=0-1',
-                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-                    'Referer': new URL(url).origin,
-                },
-                follow_max: 5,
-                response_timeout: timeout,
-                read_timeout: timeout,
-                open_timeout: timeout,
-            })
+    // 写入结果缓存
+    urlValidationCache.set(url, { valid: result.valid, reason: result.reason, time: Date.now() })
 
-            // HTTP 状态码为 2xx 或 3xx（部分音源返回 302 但有 body）均视为可达
-            if (resp.statusCode && resp.statusCode >= 200 && resp.statusCode < 400) {
-                // 排除常见错误页 MIME：音源不可能返回 HTML / JSON / 纯文本
-                const contentType = (resp.headers?.['content-type'] || '').toLowerCase()
-                if (/text\/html|application\/json|text\/plain/.test(contentType)) {
-                    result = { valid: false, reason: `URL 返回非音频内容 (${contentType}, HTTP ${resp.statusCode})` }
-                } else {
-                    // 检查是否有 body 数据或声明了 content-length
-                    const contentLength = parseInt(String(resp.headers?.['content-length'] || '0'), 10)
-                    const hasBody = Buffer.isBuffer(resp.body) ? (resp.body as Buffer).length > 0 : resp.body && String(resp.body).length > 0
-                    result = (hasBody || contentLength > 0)
-                        ? { valid: true }
-                        : { valid: false, reason: '响应体为空，URL 可能不可用' }
-                }
-            } else {
-                result = { valid: false, reason: `HTTP ${resp.statusCode || '无状态码'}` }
-            }
-        } catch (e: any) {
-            // 连接超时、DNS 解析失败、连接被拒等均视为无效
-            result = { valid: false, reason: e.message || '网络请求失败' }
-        }
+    // 缓存达到上限时清理过期条目，避免无限增长
+    if (urlValidationCache.size > URL_VALIDATION_CACHE_MAX) {
+        cleanUrlValidationCache()
+    }
 
-        // 写入结果缓存（复用已存在的条目的 reason，保证命中时返回一致）
-        urlValidationCache.set(url, { valid: result.valid, reason: result.reason, time: Date.now() })
-
-        // 缓存达到上限时清理过期条目，避免无限增长
-        if (urlValidationCache.size > URL_VALIDATION_CACHE_MAX) {
-            cleanUrlValidationCache()
-        }
-
-        return result
-    })().finally(() => {
-        // 请求结束后从进行中集合移除
-        urlValidationInFlight.delete(url)
-    })
-
-    urlValidationInFlight.set(url, promise)
-    return promise
+    return result
 }
 
 // 调用自定义源的 getMusicUrl

--- a/src/server/userApi.ts
+++ b/src/server/userApi.ts
@@ -417,45 +417,97 @@ export async function loadUserApi(apiInfo: UserApiInfo): Promise<any> {
     }
 }
 
+// ========== URL 有效性预检缓存 ==========
+// 不同音源可能返回相同的音乐 URL，已验证过的 URL 无需重复预检
+// 结果缓存：有效/无效 URL 均缓存 30 分钟
+const urlValidationCache = new Map<string, { valid: boolean; reason?: string; time: number }>()
+const URL_VALIDATION_CACHE_TTL = 30 * 60 * 1000
+const URL_VALIDATION_CACHE_MAX = 1000 // 缓存上限，防止无限增长
+
+// 进行中的预检请求：并发去重（多个音源同时返回相同 URL 时，只发一次网络请求，其余复用同一 Promise）
+const urlValidationInFlight = new Map<string, Promise<{ valid: boolean; reason?: string }>>()
+
+// 清理过期的缓存条目
+function cleanUrlValidationCache() {
+    const now = Date.now()
+    for (const [key, val] of urlValidationCache) {
+        if (now - val.time > URL_VALIDATION_CACHE_TTL) {
+            urlValidationCache.delete(key)
+        }
+    }
+}
+
 // 音乐 URL 有效性预检：通过 GET + Range 请求验证 URL 是否可播放
 async function validateMusicUrl(
     url: string,
     timeout: number = 5000
 ): Promise<{ valid: boolean; reason?: string }> {
-    try {
-        const resp = await needle('get', url, null, {
-            headers: {
-                'Range': 'bytes=0-1',
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-                'Referer': new URL(url).origin,
-            },
-            follow_max: 5,
-            response_timeout: timeout,
-            read_timeout: timeout,
-            open_timeout: timeout,
-        })
+    // 1. 命中结果缓存：同一 URL 已验证过则直接返回，不再重复预检
+    const cached = urlValidationCache.get(url)
+    if (cached && Date.now() - cached.time < URL_VALIDATION_CACHE_TTL) {
+        return { valid: cached.valid, reason: cached.reason }
+    }
 
-        // HTTP 状态码为 2xx 或 3xx（部分音源返回 302 但有 body）均视为可达
-        if (resp.statusCode && resp.statusCode >= 200 && resp.statusCode < 400) {
-            // 排除常见错误页 MIME：音源不可能返回 HTML / JSON / 纯文本
-            const contentType = (resp.headers?.['content-type'] || '').toLowerCase()
-            if (/text\/html|application\/json|text\/plain/.test(contentType)) {
-                return { valid: false, reason: `URL 返回非音频内容 (${contentType}, HTTP ${resp.statusCode})` }
+    // 2. 命中进行中的请求：并发场景下多个音源返回相同 URL，复用同一个预检 Promise
+    const inFlight = urlValidationInFlight.get(url)
+    if (inFlight) {
+        return inFlight
+    }
+
+    // 3. 发起真正的预检
+    const promise = (async () => {
+        let result: { valid: boolean; reason?: string }
+        try {
+            const resp = await needle('get', url, null, {
+                headers: {
+                    'Range': 'bytes=0-1',
+                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                    'Referer': new URL(url).origin,
+                },
+                follow_max: 5,
+                response_timeout: timeout,
+                read_timeout: timeout,
+                open_timeout: timeout,
+            })
+
+            // HTTP 状态码为 2xx 或 3xx（部分音源返回 302 但有 body）均视为可达
+            if (resp.statusCode && resp.statusCode >= 200 && resp.statusCode < 400) {
+                // 排除常见错误页 MIME：音源不可能返回 HTML / JSON / 纯文本
+                const contentType = (resp.headers?.['content-type'] || '').toLowerCase()
+                if (/text\/html|application\/json|text\/plain/.test(contentType)) {
+                    result = { valid: false, reason: `URL 返回非音频内容 (${contentType}, HTTP ${resp.statusCode})` }
+                } else {
+                    // 检查是否有 body 数据或声明了 content-length
+                    const contentLength = parseInt(String(resp.headers?.['content-length'] || '0'), 10)
+                    const hasBody = Buffer.isBuffer(resp.body) ? (resp.body as Buffer).length > 0 : resp.body && String(resp.body).length > 0
+                    result = (hasBody || contentLength > 0)
+                        ? { valid: true }
+                        : { valid: false, reason: '响应体为空，URL 可能不可用' }
+                }
+            } else {
+                result = { valid: false, reason: `HTTP ${resp.statusCode || '无状态码'}` }
             }
-            // 检查是否有 body 数据或声明了 content-length
-            const contentLength = parseInt(String(resp.headers?.['content-length'] || '0'), 10)
-            const hasBody = Buffer.isBuffer(resp.body) ? (resp.body as Buffer).length > 0 : resp.body && String(resp.body).length > 0
-            if (hasBody || contentLength > 0) {
-                return { valid: true }
-            }
-            return { valid: false, reason: '响应体为空，URL 可能不可用' }
+        } catch (e: any) {
+            // 连接超时、DNS 解析失败、连接被拒等均视为无效
+            result = { valid: false, reason: e.message || '网络请求失败' }
         }
 
-        return { valid: false, reason: `HTTP ${resp.statusCode || '无状态码'}` }
-    } catch (e: any) {
-        // 连接超时、DNS 解析失败、连接被拒等均视为无效
-        return { valid: false, reason: e.message || '网络请求失败' }
-    }
+        // 写入结果缓存（复用已存在的条目的 reason，保证命中时返回一致）
+        urlValidationCache.set(url, { valid: result.valid, reason: result.reason, time: Date.now() })
+
+        // 缓存达到上限时清理过期条目，避免无限增长
+        if (urlValidationCache.size > URL_VALIDATION_CACHE_MAX) {
+            cleanUrlValidationCache()
+        }
+
+        return result
+    })().finally(() => {
+        // 请求结束后从进行中集合移除
+        urlValidationInFlight.delete(url)
+    })
+
+    urlValidationInFlight.set(url, promise)
+    return promise
 }
 
 // 调用自定义源的 getMusicUrl


### PR DESCRIPTION
Fixes #303
从第三方音源获取URL，应该检查是否为有效 URL，可以尝试多个第三方音源获取新的有效 URL；

通过测试

日志记录流程如下

[FileCache] Lyric cached saved to: /server/cache/huwei/Love Story - Taylor Swift - 320k - Fearless (Platinum Edition).lrc  
[MusicUrl] Using custom source for: tx (ReqId: pbks934ndxms7b5clt, User: huwei)  
[UserApi] 尝试 全豆要[聚合音源] 获取 tx 音乐链接 (Owner: open)  
[UserApi] 验证 全豆要[聚合音源] 返回的 URL 有效性...  
[UserApi] 全豆要[聚合音源] 失败: 音源日志：URL 有效性预检失败: HTTP 404  
[UserApi] 尝试 Huibq_lxmusic源 获取 tx 音乐链接 (Owner: open)  
[UserApi] 尝试 念心音源 获取 tx 音乐链接 (Owner: open)  
exhigh 0013TCdl37SVzP  
[UserApi-Huibq_lxmusic源] callRequest Error: Client network socket disconnected before secure TLS connection was established  
[UserApi] Huibq_lxmusic源 失败: 音源日志：Client network socket disconnected before secure TLS connection was established  
localPromise {} tx  
exhigh 0013TCdl37SVzP  
[UserApi] 验证 念心音源 返回的 URL 有效性...  
[UserApi] ✓ 念心音源 URL 验证通过 (Owner: open)  
[DownloadProxy] Fetching: [https://car-er.kuwo.cn/18cb38f7d0891df209469be48efb584d/6a6b1879/resource/30106/trackmedia/M800000uAeYp4IWyKZ.mp3](https://car-er.kuwo.cn/18cb38f7d0891df209469be48efb584d/6a6b1879/resource/30106/trackmedia/M800000uAeYp4IWyKZ.mp3) 