### PR TITLE
fix(request): 移除全局 read_timeout，修复音频代理流被截断(~20s 掐断)回归

### DIFF
--- a/src/modules/utils/request.js
+++ b/src/modules/utils/request.js
@@ -67,8 +67,12 @@ const request = (url, options, callback) => {
         // data.content_type = 'multipart/form-data'
         options.json = false
     }
+    // 仅设置“首字节”超时(response_timeout)。不要设置 read_timeout：
+    // read_timeout 是两次数据分片之间的最大静默时间，会无差别作用于所有请求；
+    // 对长连接(音频代理流)而言，只要源站两次发包间隔超过 timeout，连接即被 abort，
+    // 表现为播放到一半(~timeout 秒)被掐断、scrobble=False。v2.0.1 无此设置且正常，故移除。
+    // 封面等短资源靠 response_timeout(首字节超时)已足够防止挂起。
     options.response_timeout = options.timeout
-    options.read_timeout = options.timeout
 
     return needle.request(options.method || 'get', url, data, options, (err, resp, body) => {
         if (!err) {

--- a/src/modules/utils/request.js
+++ b/src/modules/utils/request.js
@@ -68,9 +68,9 @@ const request = (url, options, callback) => {
         options.json = false
     }
     // 仅设置“首字节”超时(response_timeout)。不要设置 read_timeout：
-    // read_timeout 是两次数据分片之间的最大静默时间，会无差别作用于所有请求；
-    // 对长连接(音频代理流)而言，只要源站两次发包间隔超过 timeout，连接即被 abort，
-    // 表现为播放到一半(~timeout 秒)被掐断、scrobble=False。v2.0.1 无此设置且正常，故移除。
+    // Needle 的 read_timeout 是收到响应头后整个 body 读取阶段的总计时器，且不会按分片重置；
+    // 对长连接(音频代理流)而言，音频在 timeout 秒内未传输完就会被 abort 强制掐断，
+    // 表现为每首歌播放约 timeout 秒被截断、scrobble=False。v2.0.1 无此设置且正常，故移除。
     // 封面等短资源靠 response_timeout(首字节超时)已足够防止挂起。
     options.response_timeout = options.timeout
 


### PR DESCRIPTION
8578706 给全局 needle 请求助手 request.js 增加了 options.read_timeout = options.timeout。read_timeout 是两次数据分片之间的最大静默时间，会无差别作用于所有请求，导致长连接(音频代理流)在源站两次发包间隔超过 timeout 时被 abort，表现为每首歌播放约 timeout 秒被掐断、客户端判定已播完(scrobble=False)。v2.0.1 无此设置且正常，故移除该全局 read_timeout；封面等短资源仍由 response_timeout(首字节超时)防挂起。

## 📝 修改描述 (Description)

<!-- 请简要描述你修复的 Bug 或添加的功能 -->
<!-- 解决了哪个 Issue？例如：Fixes #123 -->

## 🆎 修改类型 (Type of Change)

- [ ] 🐛 Bug 修复 (Fix)
- [ ] ✨ 新功能 (Feature)
- [ ] 📚 文档修改 (Docs)
- [ ] 🔧 代码重构或优化 (Refactor/Style)

## ✅ 提交前检查清单 (Checklist)

**在提交之前，请确保你完成了以下步骤：**

- [ ] 我已将代码合并到了 **`dev`** 分支，而不是 `main`。
- [ ] 我已在本地解决了与 `dev` 分支的所有 **合并冲突 (Merge Conflicts)**。
- [ ] 我的代码在本地测试通过，没有报错。
- [ ] 我更新了对应的文档（如果适用）。

## 📸 截图 (Screenshots - 可选)
<!-- 如果是 UI 修改，请提供截图 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### 🎯 核心变更
移除全局 `needle` 请求助手中的 `options.read_timeout = options.timeout` 设置，避免音频代理流因源站分片间隔超过 `timeout` 而提前中断。保留 `response_timeout`，限制首字节等待时间。

### 📝 主要改动点
- 修改 `src/modules/utils/request.js`。
- 不再为所有请求设置 `read_timeout`。
- 保留 `response_timeout`，用于防止首字节长时间未返回。
- 修复音频播放约 `timeout` 秒后被截断，并被客户端误判为播放完成的问题。

### ⚠️ 影响与注意事项
- 未引入破坏性改动。
- 音频代理流不再受统一 `read_timeout` 限制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->